### PR TITLE
Add Ruby 3.1 and Rails 7.0 to CI

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -9,37 +9,30 @@ jobs:
   rspec:
     runs-on: ubuntu-latest
     env:
-      BUNDLE_JOBS: 4
-      BUNDLE_RETRY: 3
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7]
+        ruby: [2.6, 2.7, "3.0", 3.1]
         gemfile: [
           "gemfiles/6.1.gemfile",
+          "gemfiles/7.0.gemfile",
         ]
+        exclude:
+          - ruby: 2.6
+            gemfile: "gemfiles/7.0.gemfile"
+          - ruby: 3.1
+            gemfile: "gemfiles/6.1.gemfile"
     steps:
     - name: Install packages
       run: |
         sudo apt update -y
         sudo apt install -y libsqlite3-dev
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: /home/runner/bundle
-        key: bundle-${{ matrix.ruby }}-${{ matrix.gemfile }}-${{ hashFiles(matrix.gemfile) }}-${{ hashFiles('**/*.gemspec') }}
-        restore-keys: |
-          bundle-${{ matrix.ruby }}-${{ matrix.gemfile }}-
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: |
-        bundle config path /home/runner/bundle
-        bundle config --global gemfile ${{ matrix.gemfile }}
-        bundle install
-        bundle update
-        bundle clean
+        bundler-cache: true
     - name: Run rspec
       run: bundle exec rspec

--- a/gemfiles/7.0.gemfile
+++ b/gemfiles/7.0.gemfile
@@ -1,0 +1,8 @@
+source "http://rubygems.org"
+
+gem "rails", "~> 7.0.0"
+gem "rake", "~> 13.0"
+gem "rspec", "~> 3.0"
+gem "sqlite3"
+
+gemspec :path => "../"


### PR DESCRIPTION
This PR adds Ruby 3.1 and Rails 7.0 to the existing CI pipeline.

It also does a little simplification of the GitHub Actions pipeline.  The original, more custom pipeline was throwing errors and failing so I switched to using the common `bundler-cache` approach.

Runs green on my fork.