### PR TITLE
Add SaferInitialize.defer to avoid N+1 checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,41 @@ In `app/views/projects/index.html.haml`:
     = project.name
 ```
 
+## Deferred evaluation (avoiding N+1)
+
+`safer_initialize` runs inside `after_initialize`, which fires while each record
+is being built — *before* Rails resolves `includes`/`preload`. If your check
+touches an association, it triggers a query per record (N+1), even when the
+query eager-loads that association.
+
+Wrap the load in `SaferInitialize.defer` to queue the checks and evaluate them
+after the block finishes, once preloading is done:
+
+```ruby
+SaferInitialize.defer do
+  # Loading through `user.projects` sets the inverse for `project.user`, but not for
+  # `project.tenant` — so the tenant check's `project.tenant` needs a query per row.
+  # `includes(:tenant)` eager-loads it, but the check runs in `after_initialize` —
+  # before the preload resolves — so it still N+1s without `defer`.
+  projects = current_user.projects.includes(:tenant).to_a
+  # checks are queued here, not evaluated yet
+  render_something(projects)
+end
+# checks run at the block end — the preload is done, so `project.tenant` is cached (no N+1)
+```
+
+(`current_tenant.projects` would not N+1 here: loading through that association sets the
+inverse, so `project.tenant` is already resolved and `includes(:tenant)` is unnecessary.)
+
+Notes:
+
+- Outside a `defer` block the behavior is unchanged (immediate evaluation).
+- Globals (e.g. `tenant`) are expected to stay constant inside the block; set
+  them before entering `defer`, not within it. `with_safe` still skips checks
+  as usual.
+- If the block raises, the queue is discarded without running the checks.
+- `defer` cannot be nested.
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/gemfiles/6.1.gemfile
+++ b/gemfiles/6.1.gemfile
@@ -1,8 +1,9 @@
 source "http://rubygems.org"
 
+gem "concurrent-ruby", "1.3.4"
 gem "rails", "6.1.3.2"
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
-gem "sqlite3"
+gem "sqlite3", "~> 1.4"
 
 gemspec :path => "../"

--- a/gemfiles/7.0.gemfile
+++ b/gemfiles/7.0.gemfile
@@ -3,6 +3,6 @@ source "http://rubygems.org"
 gem "rails", "~> 7.0.0"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
-gem "sqlite3"
+gem "sqlite3", "~> 1.4"
 
 gemspec :path => "../"

--- a/lib/safer_initialize.rb
+++ b/lib/safer_initialize.rb
@@ -21,4 +21,27 @@ module SaferInitialize
   def with_safe(&block)
     Globals.set(__safe: true, &block)
   end
+
+  # Defer safer_initialize checks queued inside the block until the block
+  # finishes, so associations preloaded by the enclosed queries are already
+  # resolved by the time the checks run (avoids N+1). Globals must not be
+  # mutated inside the block. On an exception the queue is discarded without
+  # flushing. Cannot be nested.
+  def defer
+    raise Error, 'SaferInitialize.defer cannot be nested' if Globals.deferring?
+
+    Globals.__deferring = true
+    Globals.__deferred_checks = []
+
+    result = yield
+
+    checks = Globals.__deferred_checks
+    Globals.__deferring = nil
+    Globals.__deferred_checks = nil
+    checks.each(&:call)
+    result
+  ensure
+    Globals.__deferring = nil
+    Globals.__deferred_checks = nil
+  end
 end

--- a/lib/safer_initialize/active_record/extensions.rb
+++ b/lib/safer_initialize/active_record/extensions.rb
@@ -6,15 +6,24 @@ module SaferInitialize
       class_methods do
         def safer_initialize(filter = nil, message: 'initialize error', &block)
           after_initialize do |object|
-            unless SaferInitialize::Globals.safe?
-              result = filter ? object.send(filter) : object.instance_exec(object, &block)
-              unless result
-                message_text = message.respond_to?(:call) ? message.call(object) : message
-                SaferInitialize.configuration.error_handle.call(SaferInitialize::Error.new(message_text))
-              end
+            next if SaferInitialize::Globals.safe?
+
+            check = -> { SaferInitialize::ActiveRecord::Extensions.run_check(object, filter, message, block) }
+            if SaferInitialize::Globals.deferring?
+              SaferInitialize::Globals.__deferred_checks << check
+            else
+              check.call
             end
           end
         end
+      end
+
+      def self.run_check(object, filter, message, block)
+        result = filter ? object.send(filter) : object.instance_exec(object, &block)
+        return if result
+
+        message_text = message.respond_to?(:call) ? message.call(object) : message
+        SaferInitialize.configuration.error_handle.call(SaferInitialize::Error.new(message_text))
       end
     end
   end

--- a/lib/safer_initialize/globals.rb
+++ b/lib/safer_initialize/globals.rb
@@ -2,10 +2,14 @@ require 'active_support'
 
 module SaferInitialize
   class Globals < ActiveSupport::CurrentAttributes
-    attribute :__safe
+    attribute :__safe, :__deferring, :__deferred_checks
 
     def safe?
       !!__safe
+    end
+
+    def deferring?
+      !!__deferring
     end
   end
 end

--- a/spec/active_record/extensions_spec.rb
+++ b/spec/active_record/extensions_spec.rb
@@ -38,4 +38,86 @@ RSpec.describe SaferInitialize::ActiveRecord::Extensions do
       }.to raise_error(SaferInitialize::Error, 'safer_initialize is not active!')
     end
   end
+
+  describe '.defer' do
+    after { SaferInitialize::Globals.reset }
+
+    it 'delays check evaluation until the block finishes, in enqueue order' do
+      evaluated = []
+      klass = Class.new(DummyRecord) do
+        attr_accessor :label
+        safer_initialize :ok?
+        define_method(:ok?) { evaluated << label; true }
+      end
+
+      SaferInitialize.defer do
+        klass.new(label: :a)
+        klass.new(label: :b)
+        expect(evaluated).to be_empty
+      end
+
+      expect(evaluated).to eq(%i[a b])
+    end
+
+    it 'flushes at the block end and raises on violation' do
+      klass = Class.new(DummyRecord) do
+        safer_initialize(message: 'nope') { false }
+      end
+
+      expect {
+        SaferInitialize.defer { klass.new }
+      }.to raise_error(SaferInitialize::Error, 'nope')
+    end
+
+    it 'stops at the first raised check (enqueue order)' do
+      count = 0
+      klass = Class.new(DummyRecord) do
+        safer_initialize { count += 1; false }
+      end
+
+      expect {
+        SaferInitialize.defer do
+          klass.new
+          klass.new
+        end
+      }.to raise_error(SaferInitialize::Error)
+      expect(count).to eq(1)
+    end
+
+    it 'cannot be nested' do
+      expect {
+        SaferInitialize.defer { SaferInitialize.defer {} }
+      }.to raise_error(SaferInitialize::Error, 'SaferInitialize.defer cannot be nested')
+    end
+
+    it 'discards the queue without flushing when the block raises' do
+      evaluated = false
+      klass = Class.new(DummyRecord) do
+        safer_initialize { evaluated = true; false }
+      end
+
+      expect {
+        SaferInitialize.defer do
+          klass.new
+          raise 'boom'
+        end
+      }.to raise_error('boom')
+      expect(evaluated).to be(false)
+      expect(SaferInitialize::Globals.deferring?).to be(false)
+    end
+
+    it 'skips enqueue for records loaded inside with_safe' do
+      ran = false
+      klass = Class.new(DummyRecord) do
+        safer_initialize { ran = true; false }
+      end
+
+      expect {
+        SaferInitialize.defer do
+          SaferInitialize.with_safe { klass.new }
+        end
+      }.not_to raise_error
+      expect(ran).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`safer_initialize` checks run inside `after_initialize`, which fires while each
record is being built — *before* Rails resolves `includes`/`preload`. When a
check touches an association, it triggers a query per record (N+1), even when
the query eager-loads that association.

This PR adds `SaferInitialize.defer`, which queues the checks made inside the
block and evaluates them all once the block finishes. By then preloading is
done, so checks that touch associations no longer N+1.

## Usage

```ruby
SaferInitialize.defer do
  # Loading through `user.projects` sets the inverse for `project.user`, but not
  # for `project.tenant` — so the tenant check's `project.tenant` needs a query
  # per row. `includes(:tenant)` eager-loads it, but the check runs in
  # `after_initialize`, before the preload resolves, so it still N+1s without `defer`.
  projects = current_user.projects.includes(:tenant).to_a
  render_something(projects)
end
# checks run at the block end — the preload is done, so there is no N+1
```

## Behavior

- Outside a `defer` block the behavior is unchanged (immediate evaluation).
- Queued checks are evaluated in enqueue order and stop at the first violation.
- If the block raises, the queue is discarded without running the checks.
- Records loaded inside `with_safe` are skipped as before.
- `defer` cannot be nested (raises `SaferInitialize::Error`).
- Globals (e.g. `tenant`) are expected to stay constant inside the block.

## Changes

- Add `SaferInitialize.defer`.
- Add `__deferring` / `__deferred_checks` attributes and `deferring?` to `Globals`.
- Extract the `after_initialize` check into `run_check`; enqueue it while deferring.
- Add a Deferred evaluation section to the README.
- Add specs.